### PR TITLE
chore: add PR template for governance-grade change tracking

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+# Summary
+
+<!-- What does this PR change? Focus on artifact structure, usability, reproducibility, or governance. -->
+
+## Why It Matters
+
+<!-- Describe why this change is necessary. Link it to PromptOps maturity, licensing leverage, or developer onboarding. -->
+
+## Scope of Change
+
+- [ ] CI logic or eval enforcement (`ci/`, `make test`, etc.)
+- [ ] Prompt schemas, metadata, or changelogs (`schemas/`)
+- [ ] Prompt eval configs or test cases (`evals/`)
+- [ ] Logging or audit scaffolds (`logs/`, `audit/`)
+- [ ] Documentation, guides, or examples (`docs/`, `examples/`)
+- [ ] Scripts or dev tools (`scripts/`)
+- [ ] Other: \_\_\_
+
+## 🚨 Risk Level
+
+- [ ] Low – doc-only or non-blocking change
+- [ ] Medium – affects non-critical pipelines or logic
+- [ ] High – changes prompt schema, CI gating, or eval behavior
+
+## 📂 Files Touched
+
+<!-- List major folders/files updated -->
+
+## 🔍 Review Notes
+
+<!-- Anything the reviewer should focus on? Backward compatibility? Risk level? -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@
 - [ ] Logging or audit scaffolds (`logs/`, `audit/`)
 - [ ] Documentation, guides, or examples (`docs/`, `examples/`)
 - [ ] Scripts or dev tools (`scripts/`)
-- [ ] Other: \_\_\_
+- [ ] Other: (specify)
 
 ## 🚨 Risk Level
 


### PR DESCRIPTION
# 📘 Summary

This PR adds a reusable pull request template under `.github/pull_request_template.md` to enforce structured, governance-grade change tracking for all future contributions to the PromptOps Lifecycle Governance artifact.

## ✅ Why It Matters

This repository is a licensing-grade artifact intended for reuse, diligence, and SDK integration. A PR template ensures every change is documented with consistent metadata — improving audit readiness, internal traceability, and external credibility with SDK teams, buyers, and acquirers.

## 🧪 Scope of Change

* [ ] CI logic or eval enforcement (`ci/`, `make test`, etc.)
* [ ] Prompt schemas, metadata, or changelogs (`schemas/`)
* [ ] Prompt eval configs or test cases (`evals/`)
* [ ] Logging or audit scaffolds (`logs/`, `audit/`)
* [ ] Documentation, guides, or examples (`docs/`, `examples/`)
* [ ] Scripts or dev tools (`scripts/`)
* [x] Other: `.github/` infrastructure for PR workflows

## 🚨 Risk Level

* [x] Low – doc-only or non-blocking change

## 📂 Files Touched

* `.github/pull_request_template.md`

## 🔍 Review Notes

* Template is written to align with PromptOps governance principles.
* Includes scope checkboxes, risk classification, and licensing affirmation.
* Will automatically surface in GitHub PR UI after merge.
