### PR TITLE
docs: add governance-grade intro to PromptOps lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ make format         # Format Python/YAML/JSON files (optional)
 make lint           # (Optional) Run schema linter or CI sanity checks
 ```
 
+## PromptOps Documentation
+
+- [What Is PromptOps? A Practical Introduction](docs/intro-to-promptops.md)
+
 ## 📜 License & Remixing
 
 This repo is built for reuse. You are encouraged to:

--- a/docs/intro-to-promptops.md
+++ b/docs/intro-to-promptops.md
@@ -1,0 +1,199 @@
+# What Is PromptOps? A Practical Introduction to Prompt Lifecycle Governance
+
+---
+
+## Why PromptOps Exists
+
+In production environments, prompt artifacts are subject to the same risks as software code — drift, regression, brittleness, and silent failures. Yet most teams still treat prompt engineering as an ad hoc craft:
+
+- Undocumented edits in shared Notion docs
+- Prompts manually copied into frontend code with no changelog
+- Production prompts “improved” live without eval checks or rollback
+
+Here are just a few examples:
+
+- A search assistant silently stopped returning results after a junior engineer tweaked the prompt to “sound friendlier,” causing logic clauses to break — no evals, no diff, no logs.
+
+- An enterprise chatbot began hallucinating pricing info after a prompt was edited post-launch to improve tone — but no one re-ran regression evals or reviewed the change via HITL.
+
+- A support agent system degraded over weeks due to prompt drift from multiple contributors — with no prompt versioning, no rollback pipeline, and no logging. Debugging took days.
+
+**PromptOps** solves this. It introduces a **structured, reproducible governance layer** around prompts — analogous to what DevOps and MLOps provide for code and models. It answers key operational questions:
+
+- Who changed this prompt, and why?
+- Has it passed evaluation thresholds?
+- Can we revert it safely?
+- Are we logging how it behaves in production?
+- Has it gone through human-in-the-loop review?
+
+Without PromptOps, teams risk production regressions with zero visibility — and governance teams face audit blind spots that undermine buyer trust and operational safety.
+
+## What PromptOps Governs (The Core Lifecycle)
+
+PromptOps formalizes the prompt development lifecycle into six reproducible phases:
+
+### 1. **Prompt Creation + Versioning**
+
+Prompts are authored and committed using structured schemas (see: [`schemas/prompt-card.example.yml`](../schemas/prompt-card.example.yml)) with semantic versioning and metadata.
+
+```yaml
+id: onboarding-v2
+description: Improved user onboarding assistant prompt
+version: 2.1.0
+tags:
+  - onboarding
+  - assistant
+created_by: dev-a
+changelog: |
+  - Tuned tone for friendliness
+  - Improved coverage for edge-case intents
+```
+
+### 2. **Evaluation + CI Gating**
+
+Each prompt must pass CI evaluation thresholds before being eligible for promotion. Evaluations are enforced in [`ci/eval-gate.yml`](../ci/eval-gate.yml) using Promptfoo configs.
+
+```yaml
+name: Eval-Gate
+on:
+  pull_request:
+    paths:
+      - "prompts/**"
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run evals
+        run: promptfoo eval -c evals/eval-config.promptfoo.yml
+```
+
+### 3. **Human-in-the-Loop (HITL) Improvement**
+
+A formal HITL approval process ensures that prompts are reviewed and signed off before going live. See [`workflows/HITL_Approval_Template.md`](../workflows/HITL_Approval_Template.md) for the structured signoff template.
+
+### 4. **Promotion + Deployment**
+
+Approved prompts are promoted via the [`workflows/promotion-pipeline.md`](../workflows/promotion-pipeline.md), including environment tagging (e.g., `staging`, `prod`) and eval checksum locks.
+
+### 5. **Logging + Traceability**
+
+Prompt behavior in production is logged in structured form via [`logs/prompt-log-schema.json`](../logs/prompt-log-schema.json) and [`logs/agent-log.example.json`](../logs/agent-log.example.json). All executions, costs, and outcomes are traceable.
+
+### 6. **Rollback**
+
+Prompt drift or failure triggers rollback procedures described in `workflows/rollback-flow.md`. This includes prompt version selection, eval revalidation, and redeploy.
+
+---
+
+## Where PromptOps Lives in This Repo
+
+The PromptOps system is distributed across five key directories:
+
+| Folder       | Description                                           |
+| ------------ | ----------------------------------------------------- |
+| `schemas/`   | Prompt versioning schemas, dashboard prompt cards     |
+| `ci/`        | Evaluation CI gates (e.g., `eval-gate.yml`)           |
+| `workflows/` | HITL approvals, promotion logic, rollback protocol    |
+| `logs/`      | Prompt logs, cost metrics, JSON schema adherence      |
+| `evals/`     | Promptfoo eval configs, test case sets, eval criteria |
+
+These components together enforce traceability, evaluation gating, auditability, and rollback — making the prompt lifecycle safe, observable, and governable.
+
+---
+
+## What Makes PromptOps Governance-Grade
+
+PromptOps is an **auditable governance framework**.
+
+### Prompt Versioning
+
+- Each prompt tracked via [`schemas/prompt-version-schema.yml`](../schemas/prompt-version-schema.yml)
+- Semantic versioning (`x.y.z`) with embedded changelogs and tags
+- Prompts linked to test inputs and outputs via hash references
+
+### CI Evaluation Gates
+
+- `ci/eval-gate.yml` triggers evaluation runs on every pull request
+- Minimum pass thresholds enforce regression protection
+- Runs `promptfoo` against `evals/test-cases*.json` inputs
+
+```bash
+make eval
+# or manually
+promptfoo eval -c evals/eval-config.promptfoo.yml
+```
+
+### HITL Signoff Pipeline
+
+- Structured HITL approval is required for all major prompt changes
+- See: [`workflows/HITL_Approval_Template.md`](../workflows/HITL_Approval_Template.md)
+
+```md
+### HITL Approval Summary
+
+- Reviewed by: prompt-governance-lead
+- Eval Score: 92.3% pass rate (19/20)
+- Risk Notes: OK for rollout; will monitor fallback logic.
+```
+
+### ✅ Promotion + Rollback Safety
+
+- `promotion-pipeline.md` documents version tagging, eval hash pinning, and staged rollout
+- `rollback-flow.md` supports fast reversion of prompts based on logs or eval diffs
+
+### ✅ Traceable Logs
+
+- Every prompt execution optionally logged via `prompt-log-schema.json`
+- Includes version, timestamp, latency, cost, and eval ID
+
+---
+
+## ⚠️ Failure Modes Without PromptOps
+
+When PromptOps is missing, the following risk patterns emerge:
+
+| Failure Mode             | Description                                                  |
+| ------------------------ | ------------------------------------------------------------ |
+| **Prompt Drift**         | Prompts change in production without audit trail or approval |
+| **Regression Blindness** | No test coverage or CI gate → silent quality drops           |
+| **HITL Bypass**          | No human review before deployment; user trust degrades       |
+| **Rollback Failure**     | No rollback path; bad prompts stay live too long             |
+| **Untraceable Behavior** | No logs → debugging becomes guesswork                        |
+
+📎 See: [`audit/failure-modes-catalog.md`](../audit/failure-modes-catalog.md) for a categorized list of real-world breakdowns.
+
+---
+
+## What “Good” PromptOps Looks Like (In Practice)
+
+Here’s what strong PromptOps discipline looks like:
+
+- Prompts are always checked into version-controlled `prompt-card` files
+- CI enforces eval pass thresholds before merge
+- HITL reviewers verify semantic intent, not just syntax
+- Logs are available for debugging, not just auditing
+- PMs can participate in HITL and version notes without touching code
+- Engineers trust the promotion and rollback process
+
+This is the **baseline** for a reproducible, scalable, governance-grade prompt system — suitable for SaaS SDK buyers, enterprise platforms, or cloud infra teams.
+
+---
+
+## Related Artifacts and Next Steps
+
+| Artifact                                                                        | Description                                           |
+| ------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| [`schemas/prompt-version-schema.yml`](../schemas/prompt-version-schema.yml)     | Defines structure for all prompt versioning metadata  |
+| [`schemas/prompt-card.example.yml`](../schemas/prompt-card.example.yml)         | Example of a complete, versioned prompt definition    |
+| [`ci/eval-gate.yml`](../ci/eval-gate.yml)                                       | CI workflow for triggering prompt evaluations         |
+| [`workflows/rollback-flow.md`](../workflows/rollback-flow.md)                   | Safe rollback protocol for production prompt failures |
+| [`workflows/promotion-pipeline.md`](../workflows/promotion-pipeline.md)         | Promotion checklist and gating logic                  |
+| [`workflows/HITL_Approval_Template.md`](../workflows/HITL_Approval_Template.md) | Human-in-the-loop approval format                     |
+| [`logs/prompt-log-schema.json`](../logs/prompt-log-schema.json)                 | JSON schema for logging prompt usage and evaluations  |
+| [`audit/failure-modes-catalog.md`](../audit/failure-modes-catalog.md)           | Real-world governance failure patterns                |
+
+### 📘 Next Tutorial:
+
+**→ “From Version to Rollback: A Real PromptOps Lifecycle in Action”**
+
+A full lifecycle trace of a prompt through versioning, evaluation, HITL, promotion, and rollback.


### PR DESCRIPTION
# Summary

Adds a governance-grade tutorial titled **“What Is PromptOps? A Practical Introduction to Prompt Lifecycle Governance”** to `docs/`. The doc introduces core PromptOps concepts, lifecycle stages, CI enforcement, HITL flows, rollback safety, and logging architecture — grounded in real production failure scenarios. Designed for infra engineers, SDK PMs, and governance teams.

## Why It Matters

This doc fills a critical gap in PromptOps onboarding and licensing readiness:

* Explains the full PromptOps lifecycle with real repo references
* Clarifies governance-grade mechanisms for reproducibility, traceability, and auditability
* Supports developer onboarding, buyer evaluation, and acquirer diligence
* Strengthens proof layer for PromptOps as a licensing artifact 

## Scope of Change

* [ ] CI logic or eval enforcement (`ci/`, `make test`, etc.)
* [ ] Prompt schemas, metadata, or changelogs (`schemas/`)
* [ ] Prompt eval configs or test cases (`evals/`)
* [ ] Logging or audit scaffolds (`logs/`, `audit/`)
* [x] Documentation, guides, or examples (`docs/`, `examples/`)
* [ ] Scripts or dev tools (`scripts/`)
* [ ] Other: (specify)

## 🚨 Risk Level

* [x] Low – doc-only or non-blocking change
* [ ] Medium – affects non-critical pipelines or logic
* [ ] High – changes prompt schema, CI gating, or eval behavior

## 📂 Files Touched

* `docs/intro-to-promptops.md`
* `README.md` (linked new doc under PromptOps docs section, if applicable)

## 🔍 Review Notes

* Confirm all referenced file paths resolve correctly on GitHub
* Validate code blocks render as expected in markdown preview
* This doc will anchor the upcoming tutorial: **"From Version to Rollback: A Real PromptOps Lifecycle in Action"**