### PR TITLE
refactor(docs): reorganize PromptOps docs, update README, and apply g…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,16 +16,29 @@
 - [ ] Scripts or dev tools (`scripts/`)
 - [ ] Other: (specify)
 
-## 🚨 Risk Level
+## Prompt Impact
+
+If this PR updates a prompt:
+
+- [ ] Prompt card version updated (`schemas/prompt-card.*.yml`)
+- [ ] `prompt-change-log.yml` entry added
+- [ ] Related test cases added or updated (`evals/`)
+- [ ] Includes required HITL approval (`/workflows/HITL_Approval_Template.md`)
+
+## Risk Level
 
 - [ ] Low – doc-only or non-blocking change
 - [ ] Medium – affects non-critical pipelines or logic
 - [ ] High – changes prompt schema, CI gating, or eval behavior
 
-## 📂 Files Touched
+## Files Touched
 
 <!-- List major folders/files updated -->
 
-## 🔍 Review Notes
+## Review Notes
 
 <!-- Anything the reviewer should focus on? Backward compatibility? Risk level? -->
+
+---
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for contribution standards and reviewer expectations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing to PromptOps Lifecycle Governance
 
-Thanks for your interest in contributing to this project! This artifact is part of a broader AI-Native Governance Vault designed to help teams version, test, and govern prompt pipelines in production.
+Thanks for your interest in contributing to this project. This artifact is part of a broader AI-Native Governance Vault designed to help teams version, test, and govern prompt pipelines in production environments.
 
-## AI-Native Contribution Terms
+## Contribution Standards
 
 All contributions must meet human-reviewed engineering standards.
 
@@ -11,65 +11,105 @@ By submitting a pull request, you agree that:
 - You are the original author of the contribution, or
 - You have full rights to contribute the material under the MIT License.
 
-All AI-generated content must be reviewed, validated, and documented clearly. Please annotate any AI-generated code or artifacts accordingly in your PR descriptions.
+If your contribution includes any AI-generated code or content, it must be validated, clearly documented, and annotated as such in your PR description.
+
+## What You Can Contribute
+
+We welcome contributions across several domains:
+
+- Bug fixes or improvements to existing files
+- New prompt test cases, evaluation configs, or cost policies
+- Additional log schema variants or telemetry instrumentation
+- Documentation guides, walkthroughs, or usage clarifications
+- Governance patterns, safety mechanisms, or policy modules
 
 ## How to Contribute
-
-We welcome:
-
-- Bug fixes and improvements to existing files
-- New test cases, evaluation config extensions, or log schema variants
-- Clarifications, usage examples, or additional guides
-- Governance patterns and safety policy modules
 
 Before contributing:
 
 1. Fork the repository
 2. Create a feature branch
-3. Write clear, documented commits
-4. Submit a pull request with context and reasoning
+3. Make your changes with clear, documented commits
+4. Submit a pull request with purpose, context, and reasoning
 
-👉 Need orientation? Start with [`docs/dev-guide.md`](docs/dev-guide.md)
+Need orientation? Start with the [Developer Integration Guide](docs/implementation/dev-guide.md) or [Repo Tour](docs/getting-started/repo-tour.md).
 
-## ✅ What a Good PR Looks Like
+## What a Good PR Looks Like
 
-To help reviewers understand your changes, include:
+Strong pull requests typically include:
 
-1. **Purpose** — What problem does this change solve?
-2. **Prompt Impact** — Are you modifying an existing prompt? If yes:
-   - Update `prompt-card.example.yml` with a new version and hash
-   - Add a `prompt-change-log.yml` entry
-3. **Test Coverage** — Add or update entries in:
-   - `evals/test-cases.json` or `prompt-injection-tests.json`
+1. **Purpose** — A clear explanation of what the PR changes and why
+2. **Prompt Impact** — If modifying a prompt:
+   - Update `prompt-card.example.yml` or applicable prompt card
+   - Add an entry to `prompt-change-log.yml`
+3. **Test Coverage** — Ensure test cases exist in:
+   - `evals/test-cases.json`
+   - `evals/prompt-injection-tests.json` (if relevant)
 4. **CI Compliance** — Confirm `make eval` and `make test` pass
-5. **Approval Required?** — For production prompt updates, submit a HITL approval in `/reviews/`
+5. **Approval Workflows** — If updating a production prompt, include a HITL approval form under `/reviews/`
 
-### ✅ Example PR: Prompt Update
+### Example PR Title and Description
 
-feat(prompt): update support-agent prompt for better cost control
+**Title:** feat(prompt): update support-agent prompt for better cost control  
+**Description:**
 
 - Added fallback handling to avoid context explosion
-- Reduced output verbosity to lower avg tokens
+- Reduced output verbosity to lower average tokens
 - New version: v1.2.1
 - Added test case: cost regression check
-- HITL approval: ✅ included
+- HITL approval: included in `/reviews/support-agent-v1.2.1.md`
 
-## 📦 Usage & Commercial Terms
+## Documentation Contributions
 
-You are free to use, modify, and integrate this repository into your systems under the terms of the [MIT License](./LICENSE.txt).
+We encourage contributors to help improve onboarding and understanding:
 
-Commercial use is permitted with attribution. For OEM, enterprise support, or derivative licensing inquiries, contact the author directly.
+- Fix unclear language or typos
+- Add walkthroughs and explanations to the `docs/` directory
+- Clarify governance terms or versioning examples
+- Expand existing sections with patterns, use cases, or comparisons
+
+Start with [docs/index.md](docs/index.md) or the [Quickstart section](docs/getting-started/what-is-promptops.md).
+
+## File Ownership and Review Notes
+
+Certain folders require additional care:
+
+- `schemas/`, `prompts/`, `evals/` — Changes must preserve compatibility or include migration notes
+- `ci/`, `scripts/`, `Makefile` — Must pass `make test` and `make eval`
+- `docs/` — No approval required for small fixes; flag architectural changes in your PR
+
+## Repository Structure Reference
+
+For a complete overview of how the repository is structured and how components fit together, see:
+
+- [REPO_MANIFEST.md](REPO_MANIFEST.md)
+
+## Not Ready to Open a PR?
+
+We still welcome feedback. You can:
+
+- Open an issue with a bug, question, or idea
+- Propose a governance pattern or integration challenge
+- Share edge cases, drift scenarios, or evaluation methods
+
+This artifact evolves through real-world usage. If something breaks or feels confusing, that’s valuable input.
+
+## Usage and Licensing Terms
+
+This repository is licensed under the [MIT License](LICENSE.txt). You are free to use, modify, and adapt it for internal and commercial purposes with attribution.
+
+For enterprise integration, OEM redistribution, or commercial licensing inquiries, please contact the maintainer directly.
 
 ## Governance Alignment
 
-This artifact is part of a broader IP Vault focused on:
+This artifact is designed to support:
 
-- Prompt versioning and rollback safety
-- Evaluation pipelines for prompt drift and hallucination
-- Multi-agent coordination safety
-- Observability, cost control, and compliance alignment
+- Prompt versioning, rollback safety, and CI integration
+- Evaluation pipelines for drift, cost, hallucination, and injection risk
+- Multi-agent coordination with traceable logs and role schemas
+- Reproducible governance aligned with standards like OWASP, SOC2, and NIST
 
-Contributions should align with these goals whenever possible.
+Contributions that support or extend these governance goals are prioritized.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # PromptOps Lifecycle Governance
 
-> ⚠️ This repo is actively under development. Docs in progress - I’m writing walkthroughs for this artifact
+**Status:** v0.1.0 · Docs in progress · MIT licensed
 
 Governance scaffolding for prompt versioning, eval gating, rollback flows, and observability — built for SaaS SDK teams deploying AI-native systems.
 
 ## Why This Exists
 
-LLM-powered products are fragile. Prompt drift, eval regressions, agent failures, hallucinations, cost spikes — these are real problems for teams.
+LLM-powered products are fragile.
+
+Prompt drift, eval regressions, agent failures, hallucinations, cost spikes — these are real problems.
 
 This repo installs a governance scaffold into your AI pipeline to help you:
 
@@ -16,32 +18,32 @@ This repo installs a governance scaffold into your AI pipeline to help you:
 - Mitigate multi-agent and RAG failures
 - Align with OWASP and OpenTelemetry standards
 
-Think of it as “Terraform for Prompts” — declarative, reproducible, and safe to scale.
+Think of it as **“Terraform for Prompts”** — declarative, reproducible, and safe to scale.
 
 ## Who This Is For
 
-This governance scaffold is built for:
+This governance scaffold is designed for:
 
-- **SaaS SDK PMs** managing developer-facing LLM tools
-- **Infra engineers** building LangChain-style frameworks, agents, or eval layers
-- **LLM platform teams** integrating prompt pipelines into real workflows
-- **Enterprise AI governance teams** enforcing prompt safety and reproducibility
+- **SaaS SDK PMs** — managing developer-facing LLM tools
+- **Infra engineers** — building LangChain-style frameworks, agents, or eval layers
+- **LLM platform teams** — integrating prompt pipelines into real workflows
+- **AI governance teams** — enforcing prompt safety, reproducibility, and audit trails
 
 ## What’s Inside
 
-| Layer                 | Description                                                     |
-| --------------------- | --------------------------------------------------------------- |
-| `schemas/`            | Prompt version schema, changelog format, prompt card metadata   |
-| `evals/`              | Promptfoo configs, test cases (core, variants, RAG, comparison) |
-| `logs/`               | Structured log formats, cost metrics schema                     |
-| `ci/`                 | Eval gates, production enforcement rules                        |
-| `workflows/`          | Promotion pipeline, rollback plan, approval templates           |
-| `examples/`           | OWASP mapping, prompt cards, agent verification examples        |
-| `integration-guides/` | LangChain, OpenAPI, Pinecone integration tips                   |
-| `audit/`              | Failure mode catalog, log formats, HITL audit views             |
-| `scripts/`            | CLI runner, prompt card dashboard generator                     |
-| `tests/`              | Regression scenarios for different prompt types                 |
-| `docs/`               | Developer overview and walkthroughs                             |
+| Layer                 | Description                                                      |
+| --------------------- | ---------------------------------------------------------------- |
+| `schemas/`            | Prompt version schema, changelogs, canonical metadata            |
+| `evals/`              | Promptfoo configs, test cases (core, variants, RAG, comparison)  |
+| `logs/`               | Structured logging, cost metrics schema, observability formats   |
+| `ci/`                 | Eval gates, production enforcement rules                         |
+| `workflows/`          | Promotion pipelines, rollback flow, HITL approval templates      |
+| `examples/`           | OWASP mapping, agent verification chains, lifecycle walkthroughs |
+| `integration-guides/` | LangChain, OpenAPI, Pinecone integration patterns                |
+| `audit/`              | Failure mode catalog, compliance mapping, audit trail templates  |
+| `scripts/`            | CLI runners, prompt card dashboard generators                    |
+| `tests/`              | Regression scenarios for various prompt behaviors                |
+| `docs/`               | Full walkthroughs and role-specific documentation                |
 
 ## Quickstart
 
@@ -57,142 +59,73 @@ make test  # Run governance eval with CI thresholds
 Or run standalone:
 
 ```bash
-python scripts/prompt-eval-runner.py         # Non-strict preview mode
-python scripts/prompt-eval-runner.py --strict  # Strict mode (CI-style)
+python scripts/prompt-eval-runner.py         # Preview mode
+python scripts/prompt-eval-runner.py --strict  # CI enforcement
 ```
 
-## Prompt Eval Scenarios
+## Walkthroughs & Docs
 
-### Standard Eval
+- [What Is PromptOps?](docs/getting-started/what-is-promptops.md)
+- [PromptOps FAQ](docs/getting-started/faqs.md)
+- [Developer Integration Guide](docs/implementation/dev-guide.md)
+- [Agent Governance Guide](docs/governance/agent-governance.md)
+- [Full Docs Index →](docs/index.md)
 
-```bash
-promptfoo test --config evals/eval-config.promptfoo.yml
-```
-
-### Variant Prompt Eval
-
-```bash
-promptfoo test --config evals/eval-config.variant.promptfoo.yml
-```
-
-### Claude vs GPT Comparison
-
-```bash
-promptfoo test --config evals/eval-config.compare.promptfoo.yml
-```
-
-### RAG Fallback Behavior
-
-```bash
-promptfoo test --config evals/eval-config.rag.promptfoo.yml
-```
-
-> Tests for hallucination, weak context, and fallback phrasing
-
-📄 Sample report: [`evals/eval-report.rag.md`](evals/eval-report.rag.md)
-
-## Prompt Metadata & Dashboards
-
-Your canonical prompt definition lives in:
-
-- `schemas/prompt-card.example.yml` – full prompt metadata
-- `schemas/prompt-card.dashboard.yml` – dashboard-friendly view
-
-### Generate dashboard YAML from canonical source:
-
-```bash
-python scripts/generate-dashboard-card.py
-```
-
-> Syncs team-readable view for PMs, Notion, or Slack dashboards.
-
-## Governance Features
-
-- Prompt version schema + changelog tracking
-- CI gate for eval regressions + schema violations
-- Eval pipelines for Claude, GPT, variants, RAG
-- Fallback logging for multi-agent + RAG failures
-- Structured cost logs with OpenTelemetry-style schema
-- Policy-as-code examples for CI, HITL, approval gating
-- Audit log templates and OWASP LLM security mapping
-
-## Minimal Working Lifecycle Example
-
-Track the full lifecycle of `support-agent-v1`:
-
-| Stage          | File                                                               |
-| -------------- | ------------------------------------------------------------------ |
-| Metadata       | `schemas/prompt-card.example.yml`                                  |
-| Version Tags   | `schemas/prompt-version.prod-approved.yml`                         |
-| Eval Config    | `evals/eval-config.promptfoo.yml`                                  |
-| CI Gate        | `ci/ci-prod-block.yml`                                             |
-| Logs & Output  | `logs/log-sample.output.json`, `logs/prompt-log-schema.json`       |
-| Dashboard View | `schemas/prompt-card.dashboard.yml`                                |
-| RAG Behavior   | `evals/test-cases.rag.json`, `evals/eval-config.rag.promptfoo.yml` |
-| Eval Report    | `evals/eval-report.rag.md`                                         |
+---
 
 ## Key Make Commands
 
-```bash
-make eval           # Run standard prompt evals (non-blocking)
-make test           # Run governance evals and save results (CI-style)
-make strict-eval    # Enforce CI thresholds on saved eval results
-make logs           # View sample output logs
+**Eval & Test**
 
-make inject-test    # Run prompt injection test cases for jailbreak coverage
-make rag-eval       # Evaluate RAG fallback behavior (empty/vague context)
+- `make eval` — Run prompt evals
+- `make test` — Run governance evals + CI checks
+- `make inject-test`, `make rag-eval` — Run edge-case eval suites
 
-make dashboard      # Generate dashboard-friendly prompt card view
-make format         # Format Python/YAML/JSON files (optional)
-make lint           # (Optional) Run schema linter or CI sanity checks
-```
+**Dashboards & Logs**
 
-## PromptOps Documentation
+- `make dashboard` — Generate PM-friendly dashboard YAML
+- `make logs` — View sample output logs
 
-- [What Is PromptOps? A Practical Introduction](docs/intro-to-promptops.md)
+**Tooling**
 
-## 📜 License & Remixing
+- `make format`, `make lint` — Optional formatting/linting
 
-This repo is built for reuse. You are encouraged to:
+## License & Remixing
 
-- Use it inside SDKs, R&D pipelines, or internal demos
-- Remix schemas, scripts, tests, or CI flows
-- Teach or present this framework with attribution
-- Fork the repo — and send PRs if you extend it!
+This repo is built for reuse.
 
-License: MIT for internal and educational use.
+You are encouraged to:
 
-Commercial licensing is available for SDKs, cloud platforms, and enterprise teams.
+- Integrate this scaffold into SDKs, infra stacks, or platform tools
+- Fork, remix, and extend evals, changelogs, CI gates, and audit tools
+- Use this as a governance baseline for internal or regulated deployments
 
-[📧 kappainnovationllc@gmail.com](mailto:kappainnovationllc@gmail.com)
+License: [MIT](./LICENSE.txt) (internal and educational use).
+Commercial licensing available for SDKs, platform integrations, and enterprise systems.
+
+Contact: [kappainnovationllc@gmail.com](mailto:kappainnovationllc@gmail.com)
 
 ## Author
 
-Built by a solo engineer learning the full governance stack — writing docs, running tests, and evolving this artifact in public.
-→ [linkedin.com/in/houchia](https://linkedin.com/in/houchia)  
-→ [prompt-deploy.beehiiv.com](https://prompt-deploy.beehiiv.com)
+Built by [Hou Chia](https://linkedin.com/in/houchia) — a solo engineer designing governance scaffolds for AI-native teams.
 
-If this helps your team, I'd love to hear from you.
+See ongoing builds: [prompt-deploy.beehiiv.com](https://prompt-deploy.beehiiv.com)
 
-## Inspirations & Related Work
+## Inspirations
 
-This artifact draws influence from:
+This artifact draws on patterns from:
 
-- OpenTelemetry (for traceability)
-- Promptfoo (for eval pipelines)
-- Terraform (for declarative governance)
-- OWASP LLM Top 10 (for risk coverage)
+- **Promptfoo** – for prompt evaluation pipelines
+- **OpenTelemetry** – for traceable logs and cost observability
+- **Terraform** – for declarative, auditable workflows
+- **OWASP LLM Top 10** – for safety and risk mitigation
 
-## Final Notes
+---
 
-- Supports Promptfoo, LangChain, OpenAPI, Pinecone pipelines
+## Compliance & Extensibility
+
 - Compliant with OWASP LLM Top 10
-- Extendable to Claude, GPT, and open-source providers
+- Supports Promptfoo, LangChain, Pinecone, OpenAPI pipelines
+- Extendable to Claude, GPT, and open-source models
 
-For governance-grade prompt infrastructure — this is your starting scaffold.
-
-## Learn More
-
-- [Agent Governance Guide](docs/agent-governance.md)
-- [Developer Walkthrough](docs/dev-guide.md)
-- [PromptOps FAQ](docs/faqs.md)
+For governance-grade prompt infrastructure — this is your installable starting point.

--- a/docs/getting-started/adoption-checklist.md
+++ b/docs/getting-started/adoption-checklist.md
@@ -1,4 +1,4 @@
-# PromptOps Lifecycle Governance – Adoption Checklist
+# Adoption Checklist Audit: Track Governance Implementation Progress
 
 This checklist helps teams track their rollout progress of the PromptOps Lifecycle Governance framework.
 

--- a/docs/getting-started/infra-onboarding-guide.md
+++ b/docs/getting-started/infra-onboarding-guide.md
@@ -1,0 +1,3 @@
+# Onboarding PromptOps for Infra and Platform Teams
+
+Coming soon...

--- a/docs/getting-started/org-maturity-ladder.md
+++ b/docs/getting-started/org-maturity-ladder.md
@@ -1,4 +1,4 @@
-# Org Maturity Ladder – PromptOps Lifecycle Adoption
+# Use the Org Maturity Ladder: Score Governance Readiness in Your Team
 
 This ladder defines the stages an organization typically moves through as it adopts the PromptOps Lifecycle Governance framework.
 

--- a/docs/getting-started/repo-tour.md
+++ b/docs/getting-started/repo-tour.md
@@ -1,0 +1,3 @@
+# Repo Tour: How This PromptOps Governance System Is Structured
+
+Coming soon...

--- a/docs/getting-started/rollout-playbook.md
+++ b/docs/getting-started/rollout-playbook.md
@@ -1,0 +1,3 @@
+# Run a PromptOps Rollout with the Onboarding Playbook
+
+Coming soon...

--- a/docs/governance/agent-governance.md
+++ b/docs/governance/agent-governance.md
@@ -1,4 +1,4 @@
-# Agent Governance Guide
+# PromptOps for Agent Chains: Version, Log, and Gate Every Role
 
 PromptOps introduces nested agent logging, making it possible to govern and debug multi-step reasoning flows from tools like LangChain, Claude, CrewAI, ReAct-style agents, and more.
 

--- a/docs/governance/agent-log-analysis-part-ii.md
+++ b/docs/governance/agent-log-analysis-part-ii.md
@@ -1,0 +1,3 @@
+# Agent Log Analysis: Track Decisions, Observations, and Token Spend
+
+Coming soon...

--- a/docs/governance/agent-log-analysis.md
+++ b/docs/governance/agent-log-analysis.md
@@ -1,0 +1,3 @@
+# Agent Log Analysis: Trace Reasoning, Tool Use, and Output Cost Step-by-Step
+
+Coming soon...

--- a/docs/governance/agent-patterns.md
+++ b/docs/governance/agent-patterns.md
@@ -1,0 +1,3 @@
+# Designing Agent Chains: Planner → Verifier → Executor Patterns
+
+Coming soon...

--- a/docs/governance/approval-flows.md
+++ b/docs/governance/approval-flows.md
@@ -1,0 +1,3 @@
+# Approval Processes: Manual vs Automated Prompt Promotion
+
+Coming soon...

--- a/docs/governance/compliance-mapping.md
+++ b/docs/governance/compliance-mapping.md
@@ -1,4 +1,4 @@
-# Compliance & Standards Mapping
+# Compliance Mapping Guide: Link Features to Standards Like OWASP, SOC2, NIST
 
 This document maps core features of the PromptOps Lifecycle Governance artifact to emerging governance standards and buyer expectations. Use this table to demonstrate alignment with:
 

--- a/docs/governance/cost-dashboard.md
+++ b/docs/governance/cost-dashboard.md
@@ -1,4 +1,4 @@
-# PromptOps Cost Governance Dashboard
+# Cost Metrics Dashboard: Visualize Token Spend and Inference ROI
 
 Track token usage, cost risk thresholds, and monthly inference budget trends.
 

--- a/docs/governance/drift-detection.md
+++ b/docs/governance/drift-detection.md
@@ -1,0 +1,3 @@
+# Detect and Mitigate Prompt Drift: Stay Stable Across Model Updates
+
+Coming soon...

--- a/docs/governance/failure-mode-casebook.md
+++ b/docs/governance/failure-mode-casebook.md
@@ -1,0 +1,3 @@
+# Failure Mode Casebook: Real-World LLM Pitfalls and How to Catch Them
+
+Coming soon...

--- a/docs/governance/integrate-with-crewai-langgraph.md
+++ b/docs/governance/integrate-with-crewai-langgraph.md
@@ -1,0 +1,3 @@
+# Integrate PromptOps with CrewAI or LangGraph
+
+Coming soon...

--- a/docs/governance/log-field-guide.md
+++ b/docs/governance/log-field-guide.md
@@ -1,4 +1,4 @@
-# Prompt Execution Log Field Guide
+# Prompt Logging Guide: Structure Logs for Audit, Debugging, and Cost Analysis
 
 This document explains the meaning, format, and governance role of each field in the `prompt-log-schema.json` file.
 

--- a/docs/governance/log-schema-explained.md
+++ b/docs/governance/log-schema-explained.md
@@ -1,0 +1,3 @@
+# Log Schema Explained: What Each Field Means (and Why It Matters)
+
+Coming soon...

--- a/docs/governance/owasp-top10.md
+++ b/docs/governance/owasp-top10.md
@@ -1,0 +1,3 @@
+# OWASP LLM Top 10 Deep Dive: How PromptOps Maps to Each Risk
+
+Coming soon...

--- a/docs/governance/policy-as-code.md
+++ b/docs/governance/policy-as-code.md
@@ -1,0 +1,3 @@
+# Policy-as-Code Guide: Enforce Governance Rules with YAML
+
+Coming soon...

--- a/docs/governance/prompt-injection-tests.md
+++ b/docs/governance/prompt-injection-tests.md
@@ -1,0 +1,3 @@
+# Prompt Injection Testing: Add Jailbreak Scenarios to Your Eval Suite
+
+Coming soon...

--- a/docs/governance/promptops-failure-modes.md
+++ b/docs/governance/promptops-failure-modes.md
@@ -1,0 +1,3 @@
+# PromptOps Failure Modes in the Wild: What Breaks (and How to Catch It)
+
+Coming soon...

--- a/docs/governance/rag-evals.md
+++ b/docs/governance/rag-evals.md
@@ -1,0 +1,3 @@
+# RAG Eval Scenarios: Test Context Relevance, Ambiguity, and Fallback Behavior
+
+Coming soon...

--- a/docs/governance/rollback-guide.md
+++ b/docs/governance/rollback-guide.md
@@ -1,0 +1,3 @@
+# Roll Back a Bad Prompt: Respond to Eval Failures or Production Drift
+
+Coming soon...

--- a/docs/implementation/ci-eval-gates.md
+++ b/docs/implementation/ci-eval-gates.md
@@ -1,0 +1,3 @@
+# Enforcing CI Eval Gates: Block Unsafe Prompts Before They Ship
+
+Coming soon...

--- a/docs/implementation/create-prompt-card.md
+++ b/docs/implementation/create-prompt-card.md
@@ -1,0 +1,3 @@
+# Create Your First Prompt Card: A Step-by-Step Authoring Guide
+
+Coming soon...

--- a/docs/implementation/intro-to-promptfoo.md
+++ b/docs/implementation/intro-to-promptfoo.md
@@ -1,0 +1,3 @@
+# Introduction to Promptfoo Evals: Scoring Prompt Outputs with Confidence
+
+Coming soon...

--- a/docs/implementation/makefile-walkthrough.md
+++ b/docs/implementation/makefile-walkthrough.md
@@ -1,0 +1,3 @@
+# Makefile Walkthrough: Automate Eval, CI, Dashboard Sync, and More
+
+Coming soon...

--- a/docs/implementation/multi-prompt-governance.md
+++ b/docs/implementation/multi-prompt-governance.md
@@ -1,0 +1,3 @@
+# Governing Multiple Prompts: Scale Versioning, Testing, and Approval Across Teams
+
+Coming soon...

--- a/docs/implementation/prompt-design-patterns.md
+++ b/docs/implementation/prompt-design-patterns.md
@@ -1,0 +1,3 @@
+# Prompt Design Patterns: Structures That Survive CI and Promotion
+
+Coming soon...

--- a/docs/implementation/promptops-lifecycle-trace.md
+++ b/docs/implementation/promptops-lifecycle-trace.md
@@ -1,4 +1,4 @@
-# From Version to Rollback: A Real PromptOps Lifecycle in Action
+# Prompt Lifecycle Walkthrough: From Authoring to Promotion
 
 This tutorial traces a real prompt through its full governance lifecycle using this repo’s scaffolds — from versioning and evaluation to HITL signoff, promotion, logging, and rollback.
 

--- a/docs/implementation/setup-guide.md
+++ b/docs/implementation/setup-guide.md
@@ -1,0 +1,3 @@
+# Setup Guide: Run Your First Prompt Evaluation Pipeline
+
+Coming soon...

--- a/docs/implementation/sync-dashboards.md
+++ b/docs/implementation/sync-dashboards.md
@@ -1,0 +1,3 @@
+# Sync Prompt Dashboards for Teams and PMs
+
+Coming soon...

--- a/docs/implementation/troubleshooting.md
+++ b/docs/implementation/troubleshooting.md
@@ -1,0 +1,3 @@
+# Troubleshooting Guide: Fix Broken Evals, Logs, or CI Workflows
+
+Coming soon...

--- a/docs/implementation/version-and-tag.md
+++ b/docs/implementation/version-and-tag.md
@@ -1,0 +1,3 @@
+# Version and Tag a Prompt: Semantic Control for Safe Deployment
+
+Coming soon...

--- a/docs/implementation/writing-changelogs.md
+++ b/docs/implementation/writing-changelogs.md
@@ -1,0 +1,3 @@
+# Writing Prompt Changelogs: Track Edits Across Lifecycle Stages
+
+Coming soon...

--- a/docs/implementation/writing-eval-test-cases.md
+++ b/docs/implementation/writing-eval-test-cases.md
@@ -1,0 +1,3 @@
+# Writing Eval Test Cases: Define What Good Looks Like
+
+Coming soon...

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,36 +4,72 @@ Welcome to the PromptOps governance system. This artifact provides reproducible,
 
 This documentation is organized by functional role and adoption path:
 
-## Getting Started
+## Quickstart
 
-For new readers, platform teams exploring PromptOps, or anyone evaluating its purpose and architecture.
+For new engineers or platform teams installing PromptOps for the first time.
 
-- [What Is PromptOps?](getting-started/what-is-promptops.md)
+- [What Is PromptOps? A Practical Introduction to Prompt Lifecycle Governance](getting-started/what-is-promptops.md)
+- [Adoption Checklist Audit: Track Governance Implementation Progress](getting-started/adoption-checklist.md)
+- [Repo Tour: How This PromptOps Governance System Is Structured](getting-started/repo-tour.md)
+- [Run a PromptOps Rollout with the Onboarding Playbook](getting-started/rollout-playbook.md)
+- [Use the Org Maturity Ladder: Score Governance Readiness in Your Team](getting-started/org-maturity-ladder.md)
+- [Onboarding PromptOps for Infra and Platform Teams](getting-started/infra-onboarding-guide.md)
 - [FAQs](getting-started/faqs.md)
 
 ## Implementation
 
-For engineers and developers installing PromptOps workflows, running evaluations, and modifying CI pipelines.
+For engineers and developers implementing evaluations, writing prompt cards, and enforcing CI gates.
 
-- [Prompt Lifecycle Trace](implementation/promptops-lifecycle-trace.md)
+- [Setup Guide: Run Your First Prompt Evaluation Pipeline](implementation/setup-guide.md)
+- [Makefile Walkthrough: Automate Eval, CI, Dashboard Sync, and More](implementation/makefile-walkthrough.md)
+- [Create Your First Prompt Card: A Step-by-Step Authoring Guide](implementation/create-prompt-card.md)
+- [Version and Tag a Prompt: Semantic Control for Safe Deployment](implementation/version-and-tag.md)
+- [Writing Prompt Changelogs: Track Edits Across Lifecycle Stages](implementation/writing-changelogs.md)
+- [Prompt Lifecycle Walkthrough: From Authoring to Promotion](implementation/promptops-lifecycle-trace.md)
+- [Sync Prompt Dashboards for Teams and PMs](implementation/sync-dashboards.md)
+- [Prompt Design Patterns: Structures That Survive CI and Promotion](implementation/prompt-design-patterns.md)
+- [Governing Multiple Prompts: Scale Versioning, Testing, and Approval Across Teams](implementation/multi-prompt-governance.md)
+- [Introduction to Promptfoo Evals: Scoring Prompt Outputs with Confidence](implementation/intro-to-promptfoo.md)
+- [Writing Eval Test Cases: Define What Good Looks Like](implementation/writing-eval-test-cases.md)
+- [Enforcing CI Eval Gates: Block Unsafe Prompts Before They Ship](implementation/ci-eval-gates.md)
 - [Developer Integration Guide](implementation/dev-guide.md)
+- [Troubleshooting Guide: Fix Broken Evals, Logs, or CI Workflows](implementation/troubleshooting.md)
 
 ## Governance
 
-For AI governance teams, policy owners, and risk auditors validating governance pillar coverage and operational readiness.
+For AI governance teams, auditors, and platform owners implementing reproducible prompt QA.
 
-- [Agent Governance](governance/agent-governance.md)
+- [Prompt Injection Testing: Add Jailbreak Scenarios to Your Eval Suite](governance/prompt-injection-tests.md)
+- [RAG Eval Scenarios: Test Context Relevance, Ambiguity, and Fallback Behavior](governance/rag-evals.md)
+- [Detect and Mitigate Prompt Drift: Stay Stable Across Model Updates](governance/drift-detection.md)
+- [Prompt Logging Guide: Structure Logs for Audit, Debugging, and Cost Analysis](governance/log-field-guide.md)
+- [Log Schema Explained: What Each Field Means (and Why It Matters)](governance/log-schema-explained.md)
+- [Cost Metrics Dashboard: Visualize Token Spend and Inference ROI](governance/cost-dashboard.md)
+- [Policy-as-Code Guide: Enforce Governance Rules with YAML](governance/policy-as-code.md)
+- [Approval Processes: Manual vs Automated Prompt Promotion](governance/approval-flows.md)
+- [Roll Back a Bad Prompt: Respond to Eval Failures or Production Drift](governance/rollback-guide.md)
+- [OWASP LLM Top 10 Deep Dive: How PromptOps Maps to Each Risk](governance/owasp-top10.md)
+- [Failure Mode Casebook: Real-World LLM Pitfalls and How to Catch Them](governance/failure-mode-casebook.md)
+- [PromptOps Failure Modes in the Wild: What Breaks (and How to Catch It)](governance/promptops-failure-modes.md)
+- [Compliance Mapping Guide: Link Features to Standards Like OWASP, SOC2, NIST](governance/compliance-mapping.md)
+- [Agent Log Analysis: Trace Reasoning, Tool Use, and Output Cost Step-by-Step](governance/agent-log-analysis.md)
+- [Agent Log Analysis (Part II): Track Decisions, Observations, and Token Spend](governance/agent-log-analysis-part-ii.md)
 - [Agent Logging Schema](governance/agent-logging.md)
-- [Org Maturity Ladder](governance/org-maturity-ladder.md)
+- [Agent Governance](governance/agent-governance.md)
+- [Designing Agent Chains: Planner → Verifier → Executor Patterns](governance/agent-patterns.md)
+- [Integrate PromptOps with CrewAI or LangGraph](governance/integrate-with-crewai-langgraph.md)
 
 ## Licensing & Diligence
 
-For SaaS SDK buyers, platform integrators, and acquirers evaluating PromptOps as a licensing-grade governance artifact.
+For SaaS SDK buyers, platform integrators, or acquirers evaluating PromptOps as a licensing-grade governance artifact.
 
+- [PromptOps Buyer Playbook: What This Repo Offers SDK Buyers and Acquirers](licensing/buyer-playbook.md)
+- [Ship a Governed Feature End-to-End: Real PromptOps in Production](licensing/end-to-end-example.md)
+- [Govern Your First Agent: From Prompt to Eval to Audit Trail](licensing/govern-first-agent.md)
+- [Deploy a Governed RAG Pipeline: Test, Gate, and Monitor Every Step](licensing/governed-rag-pipeline.md)
 - [Onboarding Playbook](licensing/onboarding-playbook.md)
-- [Adoption Checklist](licensing/adoption-checklist.md)
-
-> `licensing-package-map.md` and `diligence-readiness-checklist.md` will be included in the next vault update.
+- [PromptOps vs AgentOps: Governance for Prompts, Agents, and Everything Between](licensing/promptops-vs-agentops.md)
+- [PromptOps QA Checklist: What to Verify Before You Ship](licensing/qa-checklist.md)
 
 ## Additional Resources
 
@@ -42,3 +78,5 @@ For SaaS SDK buyers, platform integrators, and acquirers evaluating PromptOps as
 - `schemas/` → Prompt metadata schemas and dashboards
 - `evals/` → Evaluation configs, test cases, cost-check policies
 - `logs/` → Prompt and agent output logs with schema enforcement
+
+> For full repo structure, CI usage, Makefile commands, and license terms, see the [Root README](../README.md).

--- a/docs/licensing/buyer-playbook.md
+++ b/docs/licensing/buyer-playbook.md
@@ -1,0 +1,3 @@
+# PromptOps Buyer Playbook: What This Repo Offers SDK Buyers and Acquirers
+
+Coming soon...

--- a/docs/licensing/end-to-end-example.md
+++ b/docs/licensing/end-to-end-example.md
@@ -1,0 +1,3 @@
+# Ship a Governed Feature End-to-End: Real PromptOps in Production
+
+Coming soon...

--- a/docs/licensing/govern-first-agent.md
+++ b/docs/licensing/govern-first-agent.md
@@ -1,0 +1,3 @@
+# Govern Your First Agent: From Prompt to Eval to Audit Trail
+
+Coming soon...

--- a/docs/licensing/governed-rag-pipeline.md
+++ b/docs/licensing/governed-rag-pipeline.md
@@ -1,0 +1,3 @@
+# Deploy a Governed RAG Pipeline: Test, Gate, and Monitor Every Step
+
+Coming soon...

--- a/docs/licensing/promptops-vs-agentops.md
+++ b/docs/licensing/promptops-vs-agentops.md
@@ -1,0 +1,3 @@
+# PromptOps vs AgentOps: Governance for Prompts, Agents, and Everything Between
+
+Coming soon...

--- a/docs/licensing/qa-checklist.md
+++ b/docs/licensing/qa-checklist.md
@@ -1,0 +1,3 @@
+# PromptOps QA Checklist: What to Verify Before You Ship
+
+Coming soon...

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,0 +1,30 @@
+# `prompts/` — Versioned Prompt Metadata
+
+This directory contains versioned prompt definitions used across the PromptOps lifecycle.  
+Each file follows the schema defined in `schemas/prompt-version-schema.yml` and includes:
+
+- Semantic versioning (`x.y.z`)
+- Prompt metadata (ID, description, changelog, tags)
+- Governance fields (`created_by`, `eval_id`, `promotion_stage`)
+- Compatibility with CI evaluation, HITL signoff, and rollback
+
+## Purpose
+
+The `prompts/` folder serves as the **source of truth** for all live and in-review prompt artifacts. It ensures:
+
+- Reproducibility across environments (staging, production)
+- Traceability through CI, evaluation, and promotion gates
+- Governance-readiness for audits and acquirer diligence
+
+## Schema Reference
+
+All prompt files in this directory must conform to:
+
+- [`schemas/prompt-version-schema.yml`](../schemas/prompt-version-schema.yml)
+
+## Example Files
+
+- `onboarding-v2.yml` — Improved user onboarding prompt
+- `support-agent-v1.yml` — Agent fallback prompt for support use cases
+
+> 📌 NOTE: This folder replaces `schemas/prompt-card.example.yml` as the canonical prompt metadata store.


### PR DESCRIPTION
…overnance copyedits

# Summary

This PR reorganizes and refactors the PromptOps documentation structure, updates key contributor and README files, and prepares the artifact for public visibility and rollout onboarding.

## Why It Matters

This structural overhaul improves the clarity, usability, and governance-grade reproducibility of the artifact by:

* Aligning the docs structure to adoption roles (Quickstart, Implementation, Governance, Licensing)
* Improving documentation index and README clarity for first-time repo visitors
* Supporting onboarding readiness for SDK buyers and infra teams
* Centralizing doc titles and slugs for long-term stability

## Scope of Change

* [x] Documentation, guides, or examples (`docs/`, `examples/`)
* [x] Logging or audit scaffolds (`logs/`, `audit/`)
* [x] Scripts or dev tools (`scripts/`) *(indirectly impacted via dashboard sync docs)*
* [x] Other: (README structure, contributing guidelines, pull request template)

## Risk Level

* [x] Low – doc-only or non-blocking change

## Files Touched

* `README.md` – rewritten for onboarding clarity and navigation
* `CONTRIBUTING.md` – updated to reflect stricter artifact-level review standards
* `.github/pull_request_template.md` – revised for artifact scope/risk alignment
* `docs/` – reorganized into Quickstart, Implementation, Governance, and Licensing
* `logs/` – doc-related files removed (now tracked in `docs/governance`)
* `audit/` – removed `compliance-mapping.md` (now in `docs/governance`)
* `prompts/` – directory initialized for future canonical prompt metadata

## Review Notes

* ✅ Docs are now one-to-one with the promptops.beehiiv.com writing backlog
* ✅ Slugs, titles, and folder structure match repo tour logic
* ✅ Future markdown content will now land cleanly by function/role
* No CI, eval, or code files were touched
* No dependency updates or prompt changes included