### PR TITLE
docs(readme): update root README for clarity, onboarding, and licensi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PromptOps Lifecycle Governance
 
+The installable governance artifact for safe, auditable, cost-aware LLM pipelines.
+
 **Status:** v0.1.0 · Docs in progress · MIT licensed
 
 Governance scaffolding for prompt versioning, eval gating, rollback flows, and observability — built for SaaS SDK teams deploying AI-native systems.
@@ -20,6 +22,33 @@ This repo installs a governance scaffold into your AI pipeline to help you:
 
 Think of it as **“Terraform for Prompts”** — declarative, reproducible, and safe to scale.
 
+## ❌ Before vs ✅ After Installing PromptOps Lifecycle Governance
+
+<!-- Mermaid diagram: prompt governance lifecycle -->
+
+```mermaid
+flowchart TD
+    subgraph After
+      B1[Prompt edited and versioned] --> B2[Promptfoo evals run]
+      B2 --> B3{Passes?}
+      B3 -- Yes --> B4[Promoted to prod]
+      B3 -- No --> B5[Rollback to v1.2]
+    end
+    subgraph Before
+      A1[Prompt edited manually] --> A2[No versioning]
+      A2 --> A3[Deployed to prod]
+      A3 --> A4[Customer reports bug]
+    end
+```
+
+| 🔴 Before                            | 🟢 After                                  |
+| ------------------------------------ | ----------------------------------------- |
+| Prompt edits are tribal knowledge    | All prompts versioned, logged, and diffed |
+| No CI tests or rollback path         | Eval gates + one-command rollback         |
+| Customers report failures            | Failures caught in staging, before prod   |
+| Hallucinations, cost spikes, no logs | Eval diffs, cost checks, structured logs  |
+| PMs guess what's safe to deploy      | Governance flows + promotion pipeline     |
+
 ## Who This Is For
 
 This governance scaffold is designed for:
@@ -28,6 +57,16 @@ This governance scaffold is designed for:
 - **Infra engineers** — building LangChain-style frameworks, agents, or eval layers
 - **LLM platform teams** — integrating prompt pipelines into real workflows
 - **AI governance teams** — enforcing prompt safety, reproducibility, and audit trails
+
+## How This Helps in Practice
+
+| Scenario                                   | Without PromptOps                                                                                                                            | With PromptOps                                                                                                                                         |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Agent breaks after a prompt tweak**      | A teammate tweaks the prompt to “sound more confident.” Suddenly the agent hallucinates APIs — and there’s no audit trail to debug.          | Every prompt change is versioned. Evals run automatically. If the change fails, rollback restores the last known-good version.                         |
+| **PM requests a tone update**              | A PM asks, “Can we make the assistant friendlier?” The prompt is edited live. There’s no test coverage, and subtle regressions go unnoticed. | Prompt card is updated with metadata tags. Style-only changes are eval-tested for regressions before promotion. Logs track intent, change, and result. |
+| **Cost spikes from new RAG flow**          | A new endpoint with retrieval-augmented generation increases token usage 3x. You only notice after seeing a surprise cloud bill.             | PromptOps logs token usage per prompt version. Cost spikes are flagged during CI before prod, with rollback paths if budget thresholds are exceeded.   |
+| **Invisible prompt drift in SDK**          | Developers using your SDK report inconsistent completions. But there’s no diff in the codebase, and the prompt changes weren’t tracked.      | PromptOps tracks prompt diffs across versions. Eval configs surface behavior drift. Past working versions can be restored in one command.              |
+| **Enterprise buyer asks about governance** | You scramble to answer questions about prompt safety, testing, or auditability. No formal policy, no reproducible process.                   | You share this repo: prompt versioning, CI evals, rollback flows, logs, and OWASP compliance — all demonstrable in one place.                          |
 
 ## What’s Inside
 
@@ -60,7 +99,8 @@ Or run standalone:
 
 ```bash
 python scripts/prompt-eval-runner.py         # Preview mode
-python scripts/prompt-eval-runner.py --strict  # CI enforcement
+python scripts/prompt-eval-runner.py --strict  # Enforces CI thresholds and blocks failing prompts
+
 ```
 
 ## Walkthroughs & Docs
@@ -100,8 +140,7 @@ You are encouraged to:
 - Fork, remix, and extend evals, changelogs, CI gates, and audit tools
 - Use this as a governance baseline for internal or regulated deployments
 
-License: [MIT](./LICENSE.txt) (internal and educational use).
-Commercial licensing available for SDKs, platform integrations, and enterprise systems.
+This project is licensed under the [MIT License](./LICENSE.txt). For dedicated support, enterprise integrations, or commercial licensing options, please contact us.
 
 Contact: [kappainnovationllc@gmail.com](mailto:kappainnovationllc@gmail.com)
 


### PR DESCRIPTION
# Summary

Updates the root `README.md` to provide a comprehensive overview of the PromptOps Lifecycle Governance artifact. This includes clarified purpose, real-world usage examples, artifact structure breakdown, onboarding instructions, licensing guidance, and extensibility notes.

## Why It Matters

PromptOps is a governance-grade artifact designed to be installed, reused, and licensed. A weak or underexplained README blocks onboarding, collaboration, and perceived value.

This update:

- Strengthens the artifact’s **licensing leverage**
- Aligns the documentation with **governance-grade maturity**
- Equips **SDK buyers, infra leads, and governance teams** with a clear mental model
- Establishes PromptOps as **"Terraform for Prompts"** — with versioning, CI, and rollback scaffolds

## Scope of Change

- [ ] CI logic or eval enforcement (`ci/`, `make test`, etc.)
- [ ] Prompt schemas, metadata, or changelogs (`schemas/`)
- [ ] Prompt eval configs or test cases (`evals/`)
- [ ] Logging or audit scaffolds (`logs/`, `audit/`)
- [ ] Documentation, guides, or examples (`docs/`, `examples/`)
- [ ] Scripts or dev tools (`scripts/`)
- [x] Other: `README.md` (top-level artifact overview)

## Prompt Impact

If this PR updates a prompt:

- [ ] Prompt card version updated (`schemas/prompt-card.*.yml`)
- [ ] `prompt-change-log.yml` entry added
- [ ] Related test cases added or updated (`evals/`)
